### PR TITLE
Fix: Correct Playwright MCP server package name

### DIFF
--- a/components/MCP/MCPQuickAdd.vue
+++ b/components/MCP/MCPQuickAdd.vue
@@ -855,9 +855,9 @@ const serverTemplates: MCPServerTemplate[] = [
     detailedDescription: 'Automate Chromium, Firefox and WebKit with a single API.',
     icon: 'mdi:web',
     type: 'stdio',
-    installCommand: 'npx -y @modelcontextprotocol/server-playwright',
+    installCommand: 'npm install -g @playwright/mcp',
     command: 'npx',
-    args: ['-y', '@modelcontextprotocol/server-playwright'],
+    args: ['@playwright/mcp'],
     category: 'automation'
   },
   {

--- a/docs/MCP_POPULAR_SERVERS.md
+++ b/docs/MCP_POPULAR_SERVERS.md
@@ -212,7 +212,7 @@ This document lists the popular MCP servers integrated into the Clode Studio's q
 ### Playwright
 - **Description**: Cross-browser automation
 - **Type**: stdio
-- **Install**: `npm install -g @modelcontextprotocol/server-playwright`
+- **Install**: `npm install -g @playwright/mcp`
 - **Use Case**: Multi-browser testing
 
 ### Browser Control


### PR DESCRIPTION
## Summary
- Fixed incorrect Playwright MCP server package name from `@modelcontextprotocol/server-playwright` to `@playwright/mcp`
- Updated both the Vue component and documentation

## Changes
- Updated `components/MCP/MCPQuickAdd.vue` to use correct package name
- Updated `docs/MCP_POPULAR_SERVERS.md` documentation

Fixes #6