### PR TITLE
feat: add keyboard handling for newline insertion in terminal

### DIFF
--- a/components/Terminal/ClaudeTerminalTab.vue
+++ b/components/Terminal/ClaudeTerminalTab.vue
@@ -173,12 +173,30 @@ const initTerminal = () => {
     fastScrollSensitivity: 5,
     windowsMode: false
   });
-  
+
   fitAddon = new FitAddon();
   terminal.loadAddon(fitAddon);
   
   terminal.open(terminalElement.value);
   fitAddon.fit();
+
+  terminal.attachCustomKeyEventHandler((event: KeyboardEvent) => {
+    console.log('Custom key handler attached for Shift+Enter');
+    
+    // Block Option+Enter (Alt+Enter) - prevent xterm's default behavior
+    if (event.type === 'keydown' && event.key === 'Enter' && event.altKey) {
+      return false;
+    }
+
+    // Handle Shift+Enter for inserting a newline
+    if (event.type === 'keydown' && event.key === 'Enter' && event.shiftKey) {
+      event.preventDefault();
+      terminal.paste('\n');
+      return false;
+    }
+
+    return true;
+  });
   
   terminal.onScroll(() => {
     const buffer = terminal.buffer.active;


### PR DESCRIPTION
## Summary
- Add custom keyboard event handling to improve multi-line text entry in terminal
- Handle Shift+Enter for newline insertion
- Block Option+Enter to prevent conflicts with xterm defaults

## Changes
- Added custom key event handler to terminal initialization in `ClaudeTerminalTab.vue`
- Implemented Shift+Enter handling to insert newlines using terminal.paste('\n')
- Blocked Option+Enter (Alt+Enter) to prevent xterm's default behavior

## Testing
- [x] Tested Shift+Enter inserts newlines correctly
- [x] Verified Option+Enter is properly blocked
- [x] Ensured normal Enter key behavior remains unchanged

Resolves #8