### PR TITLE
Fix: Use static import for readdirSync instead of dynamic require

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+# IDEs
+.idea/
+
+# Nuxt.js build output
+.nuxt/
+
+# Electron generated files
+electron/*.js
+!electron/claude-sdk-service.js
+
+# Dependencies
+node_modules/
+package-lock.json
+
+# Environment variables
+.env
+
+# Clode Studio related files and directories
+.claude-checkpoints/
+.worktrees/
+.claude/

--- a/electron/claude-detector.ts
+++ b/electron/claude-detector.ts
@@ -1,6 +1,6 @@
 import { exec } from 'child_process';
 import { promisify } from 'util';
-import { existsSync } from 'fs';
+import { existsSync, readdirSync } from 'fs';
 import { join } from 'path';
 
 const execAsync = promisify(exec);
@@ -144,7 +144,6 @@ export class ClaudeDetector {
         // Check for Claude in any Node version
         const nodeVersionsDir = join(nvmDir, 'versions', 'node');
         if (existsSync(nodeVersionsDir)) {
-          const { readdirSync } = require('fs');
           const versions = readdirSync(nodeVersionsDir);
           for (const version of versions) {
             const claudePath = join(nodeVersionsDir, version, 'bin', 'claude');


### PR DESCRIPTION
## Summary
- Refactors the import of `readdirSync` from a dynamic `require()` to a static import at the top of the file
- Improves code consistency and follows ES module best practices

## Test plan
- [x] Verify that Claude detection still works properly
- [x] Ensure the file imports are consistent throughout the codebase

Fixes #21