### PR TITLE
feat: improve .gitignore handling to prevent duplicate entries

### DIFF
--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -271,7 +271,8 @@ const electronAPI = {
     discardChanges: (files: string[]) => ipcRenderer.invoke('git:discardChanges', files),
     init: () => ipcRenderer.invoke('git:init'),
     clone: (url: string, localPath?: string) => ipcRenderer.invoke('git:clone', url, localPath),
-    checkIsRepo: () => ipcRenderer.invoke('git:checkIsRepo')
+    checkIsRepo: () => ipcRenderer.invoke('git:checkIsRepo'),
+    checkIgnore: (workspacePath: string, paths: string[]) => ipcRenderer.invoke('git:checkIgnore', workspacePath, paths)
   },
   checkpoint: {
     init: () => ipcRenderer.invoke('checkpoint:init'),

--- a/stores/checkpoint-v2.ts
+++ b/stores/checkpoint-v2.ts
@@ -471,53 +471,55 @@ export const useCheckpointV2Store = defineStore('checkpoint-v2', () => {
       // Create .claude-checkpoints directory
       await window.electronAPI.fs.ensureDir(shadowRepoPath.value);
       
-      // Update .gitignore in parent directory to ignore our directories
+      // Update .gitignore in parent directory to ignore our directories (only if not already ignored)
       const workspacePath = shadowRepoPath.value.replace('/.claude-checkpoints', '');
-      const gitignorePath = `${workspacePath}/.gitignore`;
-      const gitignoreContent = await window.electronAPI.fs.readFile(gitignorePath);
       
-      // Entries we need to add
-      const claudeEntries = [
-        '# Claude Code IDE generated directories',
-        '.claude-checkpoints/',
-        '.worktrees/',
-        '.claude/'
-      ];
+      // Check which paths are already ignored by git
+      const pathsToCheck = ['.claude-checkpoints', '.worktrees', '.claude'];
+      let dirsToAdd = pathsToCheck;
       
-      if (gitignoreContent.success && gitignoreContent.content) {
-        // File exists, check if it includes our entries
-        let contentToAppend = '';
+      try {
+        const ignoreResults = await window.electronAPI.git.checkIgnore(workspacePath, pathsToCheck);
         
-        if (!gitignoreContent.content.includes('.claude-checkpoints')) {
-          if (!contentToAppend && gitignoreContent.content.trim()) {
-            contentToAppend += '\n'; // Add newline if file has content
+        if (ignoreResults.success) {
+          // If git is available and it's a git repo, only add directories that are not already ignored
+          if (ignoreResults.isGitRepo !== false && ignoreResults.gitAvailable !== false) {
+            dirsToAdd = pathsToCheck.filter(path => !ignoreResults.results[path]);
           }
-          contentToAppend += claudeEntries[0] + '\n' + claudeEntries[1] + '\n';
+          // Otherwise (not a git repo or git not available), add all directories to be safe
         }
-        
-        if (!gitignoreContent.content.includes('.worktrees')) {
-          if (!contentToAppend && !gitignoreContent.content.includes('.claude-checkpoints')) {
-            contentToAppend += '\n' + claudeEntries[0] + '\n';
+      } catch (error) {
+        // If check fails, add all directories to be safe
+        console.log('Failed to check git ignore status, will add all directories');
+      }
+      
+      if (dirsToAdd.length > 0) {
+          const gitignorePath = `${workspacePath}/.gitignore`;
+          const gitignoreContent = await window.electronAPI.fs.readFile(gitignorePath);
+          
+          // Entries we need to add
+          const claudeEntries = [
+            '# Claude Code IDE generated directories',
+            ...dirsToAdd.map(dir => dir + '/')
+          ];
+          
+          if (gitignoreContent.success && gitignoreContent.content) {
+            // File exists, append our entries
+            let contentToAppend = '';
+            
+            if (gitignoreContent.content.trim()) {
+              contentToAppend += '\n'; // Add newline if file has content
+            }
+            contentToAppend += claudeEntries.join('\n') + '\n';
+            
+            await window.electronAPI.fs.writeFile(
+              gitignorePath,
+              gitignoreContent.content + contentToAppend
+            );
           }
-          contentToAppend += claudeEntries[2] + '\n';
-        }
-        
-        if (!gitignoreContent.content.includes('.claude/')) {
-          if (!contentToAppend && !gitignoreContent.content.includes('.claude-checkpoints') && !gitignoreContent.content.includes('.worktrees')) {
-            contentToAppend += '\n' + claudeEntries[0] + '\n';
-          }
-          contentToAppend += claudeEntries[3] + '\n';
-        }
-        
-        if (contentToAppend) {
-          await window.electronAPI.fs.writeFile(
-            gitignorePath,
-            gitignoreContent.content + contentToAppend
-          );
-        }
-      } else {
-        // File doesn't exist, create it with common defaults + our entries
-        const defaultGitignore = `# Dependencies
+          } else {
+            // File doesn't exist, create it with common defaults + our entries
+            const defaultGitignore = `# Dependencies
 node_modules/
 npm-debug.log*
 yarn-debug.log*
@@ -549,10 +551,12 @@ coverage/
 
 ${claudeEntries.join('\n')}
 `;
-        await window.electronAPI.fs.writeFile(
-          gitignorePath,
-          defaultGitignore
-        );
+            await window.electronAPI.fs.writeFile(
+              gitignorePath,
+              defaultGitignore
+            );
+          }
+        }
       }
       
       // Initialize shadow repo through checkpoint service


### PR DESCRIPTION
## Summary
- Adds intelligent .gitignore handling that checks if directories are already ignored before adding them
- Prevents duplicate entries and respects existing gitignore patterns
- Improves robustness when git is not available

## Changes
- Added `git:checkIgnore` IPC handler in main.ts to check if paths are already ignored by git
- Modified checkpoint-service.ts to use git check-ignore before updating .gitignore
- Updated checkpoint-v2.ts store to check ignore status before adding entries
- Added proper error handling for cases where git is not available

## Benefits
- Cleaner .gitignore files without duplicate entries
- Respects existing gitignore patterns (e.g., if user already has `.*` pattern)
- Better integration with existing project configurations
- Graceful fallback when git is not available

## Test plan
- [ ] Test initialization in a git repository with existing .gitignore
- [ ] Test initialization in a non-git directory
- [ ] Test when git command is not available
- [ ] Verify no duplicate entries are added to .gitignore
- [ ] Verify directories already covered by patterns are not added

Fixes #26